### PR TITLE
대표 블로그가 가장 최상위에 출력되도록 수정

### DIFF
--- a/src/renderer/components/index/BlogList.js
+++ b/src/renderer/components/index/BlogList.js
@@ -11,7 +11,9 @@ class BlogList extends Component {
     return (
       <div className="blog_list">
         <List>
-          {blogs.map(blog =>
+          {blogs.sort((a,b) =>
+						a.default > b.default ? -1 : 1
+					).map(blog =>
             <BlogListItem key={blog.url} blog={blog} onSelect={onSelect} />
           )}
         </List>


### PR DESCRIPTION
- 로그인 후 블로그 목록 보여질 때, 대표 블로그가 가장 위에 오도록 수정.

블로그가 여러 개일 경우 불편할 것 같아서 수정해보았습니다. 불필요하다 생각되시면 삭제하시기 바랍니다.