### PR TITLE
feat: 텀블러 NPF 기능 제한을 위한 Tiptap 에디터 수정

### DIFF
--- a/src/renderer/components/editor/tiptap/MenuBar.tsx
+++ b/src/renderer/components/editor/tiptap/MenuBar.tsx
@@ -6,7 +6,6 @@ import {
   FormatItalic,
   FormatListBulleted,
   FormatListNumbered,
-  Code,
   Image as ImageIcon,
   GridView,
   LayersClear,
@@ -85,14 +84,6 @@ export default function MenuBar({ editor, onImageClick, onAddLink, onAddLinkCard
         >
           <FormatItalic />
         </ToggleButton>
-        <ToggleButton
-          value="code"
-          selected={editor.isActive('code')}
-          onClick={() => editor.chain().focus().toggleCode().run()}
-          sx={styles.toolbarBtn}
-        >
-          <Code />
-        </ToggleButton>
       </ToggleButtonGroup>
 
       <Divider orientation="vertical" flexItem sx={{ mx: 1 }} />
@@ -113,14 +104,6 @@ export default function MenuBar({ editor, onImageClick, onAddLink, onAddLinkCard
           sx={{ ...styles.toolbarBtn, fontWeight: 'bold', fontSize: '12px' } as SxProps<Theme>}
         >
           H2
-        </ToggleButton>
-        <ToggleButton
-          value="h3"
-          selected={editor.isActive('heading', { level: 3 })}
-          onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
-          sx={{ ...styles.toolbarBtn, fontWeight: 'bold', fontSize: '11px' } as SxProps<Theme>}
-        >
-          H3
         </ToggleButton>
       </ToggleButtonGroup>
 

--- a/src/renderer/components/editor/tiptap/TiptapEditor.tsx
+++ b/src/renderer/components/editor/tiptap/TiptapEditor.tsx
@@ -59,7 +59,16 @@ export default function TiptapEditor({ value, onChange }: TiptapEditorProps) {
 
   const editor = useEditor({
     extensions: [
-      StarterKit,
+      StarterKit.configure({
+        heading: {
+          levels: [1, 2],
+        },
+        blockquote: false,
+        codeBlock: false,
+        horizontalRule: false,
+        strike: false,
+        code: false,
+      }),
       Image,
       ImageGroup,
       LinkCard,


### PR DESCRIPTION
Tumblr NPF 제약 사항에 맞춰 Tiptap 에디터의 기능을 제한합니다.

- Heading 레벨 2 이하로 제한
- blockquote, codeBlock, horizontalRule 노드 비활성화 및 마크다운 자동 완성 제한
- strike, code 인라인 마크 비활성화
- 에디터 툴바에서 H3 및 Code 버튼 제거