### PR TITLE
fix: 에디터 내 링크 클릭 시 외부 브라우저 오픈 차단

### DIFF
--- a/src/renderer/components/editor/tiptap/TiptapEditor.tsx
+++ b/src/renderer/components/editor/tiptap/TiptapEditor.tsx
@@ -199,6 +199,28 @@ export default function TiptapEditor({ value, onChange }: TiptapEditorProps) {
     }
   }, [value, editor])
 
+  // 에디터 컨테이너 내부의 모든 A 태그 클릭 이벤트를 캡처링 단계에서 가로채서 기본 동작(외부 브라우저 열기)을 취소함
+  useEffect(() => {
+    const container = editorContainerRef.current
+    if (!container) return
+
+    const handleLinkClick = (event: MouseEvent) => {
+      let target = event.target as Node | null
+      while (target && target !== container) {
+        if (target.nodeName === 'A') {
+          event.preventDefault()
+          break
+        }
+        target = target.parentNode
+      }
+    }
+
+    container.addEventListener('mousedown', handleLinkClick, true)
+    return () => {
+      container.removeEventListener('mousedown', handleLinkClick, true)
+    }
+  }, [editor])
+
   return (
     <ThemeProvider theme={lightTheme}>
       <Box sx={styles.root}>


### PR DESCRIPTION
에디터 내에 포함된 인라인 링크를 클릭 시 외부 브라우저 창이 뜨는 현상을 방지하기 위해 mousedown 이벤트의 캡처링 단계를 가로채서 preventDefault()를 처리하도록 수정했습니다.